### PR TITLE
hook into the snippet editor popupLoad

### DIFF
--- a/Stack Snippets Intellisense.user.js
+++ b/Stack Snippets Intellisense.user.js
@@ -13,7 +13,8 @@ window.require = {
 };
 
 $(function() {
-    $(document).on("click", ".wmd-snippet-button", function() {
+    $(document).on("popupLoad", function(e) {
+        if (!e.popup || !e.popup.hasClass || !e.popup.hasClass('popup-snippet')) return;
         window.MonacoEnvironment = window.MonacoEnvironment || {
             getWorkerUrl: function (workerId, label)
             {


### PR DESCRIPTION
Snippet popups can be opened from other places, not just the markdown editor toolbar. This should handle all of them.
